### PR TITLE
Python auto-formatting for VS Code

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,17 @@
+[style]
+based_on_style = pep8
+blank_lines_between_top_level_imports_and_variables=2
+blank_line_before_class_docstring=True
+blank_line_before_module_docstring=True
+blank_line_before_nested_class_or_def=True
+coalesce_brackets=True
+column_limit=90
+continuation_indent_width = 2
+dedent_closing_brackets=True
+indent_dictionary_value=True
+indent_width = 2
+spaces_around_dict_delimiters=True
+spaces_around_list_delimiters=True
+split_arguments_when_comma_terminated=False
+split_before_first_argument=True
+split_before_expression_after_opening_paren=True

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.pylintPath": "pylint",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
+    "python.formatting.provider": "yapf",
+    "editor.rulers": [
+        90
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/mdhhockey/constants.py
+++ b/mdhhockey/constants.py
@@ -42,7 +42,10 @@ NUM_YEARS_DATA_TO_FETCH = 10
 # These players are not on ANY draft results or teams page. I believe this
 # is because they are A) undrafted, B) haven't played an NHL game, and C)
 # rostered in Fantrax.
-MISSING_PLAYERS = set(['Brandon Bussi', 'Ryan McAllister', 'Daniel Vladar', 'Georgi Merkulov'])
+MISSING_PLAYERS = set([
+  'Brandon Bussi', 'Ryan McAllister', 'Daniel Vladar', 'Georgi Merkulov'
+])
+
 
 class _K:
   BDAY = 'birthDate'

--- a/mdhhockey/helpers.py
+++ b/mdhhockey/helpers.py
@@ -1,8 +1,9 @@
 import json
 import os
-import requests
 import traceback
 from datetime import date, datetime
+
+import requests
 
 from mdhhockey.constants import (CACHE_DIR, NHL_API_BASE_URL, PLAYERS_CACHE_SUBDIR)
 


### PR DESCRIPTION
* Added a `.vscode/settings.json` file, which enables "format on save" for Python files. Formatting will use [yapf formatter](https://github.com/google/yapf). Styling rules are defined in the new `.style.yapf` file.
* Applied the formatting to all existing Python files